### PR TITLE
blog-template: use c8 for coverage reports

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,22 @@
+{
+  "enabled": false,
+  "clean": true,
+  "cleanOnRerun": false,
+  "reportsDirectory": "./coverage",
+  "excludeNodeModules": true,
+  "reporter": ["text", "html"],
+  "allowExternal": false,
+  "extension": [".js", ".cjs", ".mjs", ".ts", ".tsx", ".jsx", ".vue", "svelte"],
+  "exclude": [
+    "coverage/**",
+    "packages/*/test{,s}/**",
+    "**/*.d.ts",
+    "cypress/**",
+    "test{,s}/**",
+    "test{,-*}.{js,cjs,mjs,ts,tsx,jsx}",
+    "**/*{.,-}test.{js,cjs,mjs,ts,tsx,jsx}",
+    "**/__tests__/**",
+    "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc}.config.{js,cjs,mjs,ts}",
+    "**/.{eslint,mocha}rc.{js,cjs}"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm run build:client && npm run build:server",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "npm run test -- --coverage",
+    "test:coverage": "c8 report",
     "lint": "eslint \"{src,server}/**/*.{ts,tsx}\"",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx}\" \"server/**/*.ts\"",


### PR DESCRIPTION
* track https://github.com/vitest-dev/vitest/issues/691
* add c8 config from vitest