### PR TITLE
blog-template: server: set custom host when port is set in env

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -16,7 +16,7 @@ import { join } from 'path';
 import { AppModule } from '@server/app/AppModule';
 
 const port = process.env.PORT || 3000;
-const host = process.env.HOST || 'localhost';
+const host = process.env.PORT ? '::' : 'localhost';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter());


### PR DESCRIPTION
* heroku doesn't allow binding to 127.0.0.1 which is default for fastify